### PR TITLE
Update CW config with list of `metric_name_selectors`

### DIFF
--- a/sample-configs/operator/collector-config-cloudwatch.yaml
+++ b/sample-configs/operator/collector-config-cloudwatch.yaml
@@ -327,6 +327,7 @@ spec:
       # Each dimension must alredy exist as a label on the Prometheus metric
       # For each set of dimensions, add a list of metrics under the metric_name_selectors field
       # Metrics names may be listed explicitly or using regular expressions
+      # A default list of metrics has been provided
       # Data from performance log events will be aggregated by CloudWatch using these dimensions to create a CloudWatch custom metric
       #    
       awsemf:
@@ -339,6 +340,11 @@ spec:
         parse_json_encoded_attr_values: [Sources, kubernetes]
         metric_declarations:
           - dimensions: [[EKS_Cluster, EKS_Namespace, EKS_PodName]]
+            metric_name_selectors:
+              - apiserver_request_.*
+              - container_memory_.*
+              - container_threads
+              - otelcol_process_.*
     service:
       pipelines:
         metrics:


### PR DESCRIPTION
Update to the CloudWatch configuration to provide default list of `metric_name_selectors`, to reduce steps in applying configuration