### PR TITLE
Update collector-config-amp.yaml with serviceAccount: adot-collector

### DIFF
--- a/sample-configs/operator/collector-config-amp.yaml
+++ b/sample-configs/operator/collector-config-amp.yaml
@@ -9,7 +9,7 @@ metadata:
   name: my-collector-amp
 spec:
   mode: deployment
-  serviceAccount: adot-demo
+  serviceAccount: adot-collector
   podAnnotations:
     prometheus.io/scrape: 'true'
     prometheus.io/port: '8888'


### PR DESCRIPTION
Changing serviceAccount: adot-demo to serviceAccount: adot-collector to be consistent between YAML files, the ADOT getting started guide (https://aws-otel.github.io/docs/getting-started/adot-eks-add-on), and the EKS docs (https://docs.aws.amazon.com/eks/latest/userguide/deploy-collector.html).