### PR TITLE
Update collector-config-xray.yaml with serviceAccount: adot-collector

### DIFF
--- a/sample-configs/operator/collector-config-xray.yaml
+++ b/sample-configs/operator/collector-config-xray.yaml
@@ -4,7 +4,7 @@ metadata:
   name: my-collector-xray
 spec:
   mode: deployment 
-  serviceAccount: adot-demo
+  serviceAccount: adot-collector
   config: |
     receivers:
       otlp:


### PR DESCRIPTION
Changing serviceAccount: adot-demo to serviceAccount: adot-collector to be consistent between YAML files, the ADOT getting started guide (https://aws-otel.github.io/docs/getting-started/adot-eks-add-on), and the EKS docs (https://docs.aws.amazon.com/eks/latest/userguide/deploy-collector.html).