### PR TITLE
Update collector-config-cloudwatch.yaml - 2nd instance of adot-demo also needs to be updated

### DIFF
--- a/sample-configs/operator/collector-config-cloudwatch.yaml
+++ b/sample-configs/operator/collector-config-cloudwatch.yaml
@@ -395,5 +395,5 @@ roleRef:
   name: otel-prometheus-role
 subjects:
   - kind: ServiceAccount
-    name: adot-demo
+    name: adot-collector
     namespace: default


### PR DESCRIPTION
Second instance of adot-demo needs to be changed to adot-collector.

Description:

Link to tracking Issue:

Testing Performed:

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

