### PR TITLE
Incorrect service account in ClusterRoleBinding

### DIFF
--- a/sample-configs/operator/collector-config-amp.yaml
+++ b/sample-configs/operator/collector-config-amp.yaml
@@ -354,5 +354,5 @@ roleRef:
   name: otel-prometheus-role
 subjects:
   - kind: ServiceAccount
-    name: adot-demo
+    name: adot-collector
     namespace: default


### PR DESCRIPTION

Description:
Fixed service account in cluster role binding to point to the adot-collector service account which is created in previous steps.

Link to tracking Issue:

Testing Performed:

Created a new EKS cluster and AMP workspace with fixed yaml for collector CRD and confirmed metrics ingestion into AMP instance through AMG dashboards. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

