### PR TITLE
Update stable opentelemetry-Python dependencies 1.12.0 and 0.33.b0

### DIFF
--- a/sample-apps/python-auto-instrumentation-sample-app/requirements.txt
+++ b/sample-apps/python-auto-instrumentation-sample-app/requirements.txt
@@ -1,10 +1,10 @@
 boto3==1.24.40
 Flask==2.1.3
-opentelemetry-distro==0.32b0
-opentelemetry-exporter-otlp==1.12.0rc2
-opentelemetry-api==1.12.0rc2
-opentelemetry-instrumentation-flask==0.32b0
-opentelemetry-instrumentation-requests==0.32b0
+opentelemetry-distro==0.33b0
+opentelemetry-exporter-otlp==1.12.0
+opentelemetry-api==1.12.0
+opentelemetry-instrumentation-flask==0.33b0
+opentelemetry-instrumentation-requests==0.33b0
 opentelemetry-sdk-extension-aws==2.0.1
 opentelemetry-propagator-aws-xray==1.0.1
 protobuf==3.20.1


### PR DESCRIPTION
Description:

This PR updates the OTEL-Python to `1.12.0` and 0.33b0 contrib dependencies

Link to tracking Issue:

Testing Performed:

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

