### PR TITLE
Add missing dependency

### DIFF
--- a/sample-apps/java-sample-app/base/build.gradle.kts
+++ b/sample-apps/java-sample-app/base/build.gradle.kts
@@ -38,6 +38,7 @@ dependencies {
     implementation("org.yaml:snakeyaml:1.8")
     implementation("org.apache.logging.log4j:log4j-api:2.18.0")
     implementation("org.apache.logging.log4j:log4j-core:2.18.0")
+    implementation("org.slf4j:slf4j-simple:2.0.3")
 
 }
 


### PR DESCRIPTION
Fix missing logging dependency that was causing warning message:
```
logger - opentelemetry-javaagent - version: 1.17.0-aws
SLF4J: Failed to load class "org.slf4j.impl.StaticLoggerBinder".
SLF4J: Defaulting to no-operation (NOP) logger implementation
SLF4J: See 
```
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

