### PR TITLE
Update examples for fargate

### DIFF
--- a/sample-configs/operator/collector-config-amp.yaml
+++ b/sample-configs/operator/collector-config-amp.yaml
@@ -13,6 +13,11 @@ spec:
   podAnnotations:
     prometheus.io/scrape: 'true'
     prometheus.io/port: '8888'
+  resources:
+    requests:
+      cpu: "1"
+    limits:
+      cpu: "1"
   config: |
     extensions:
       sigv4auth:

--- a/sample-configs/operator/collector-config-cloudwatch.yaml
+++ b/sample-configs/operator/collector-config-cloudwatch.yaml
@@ -13,6 +13,11 @@ spec:
   podAnnotations:
     prometheus.io/scrape: 'true'
     prometheus.io/port: '8888'
+  resources:
+    requests:
+      cpu: "1"
+    limits:
+      cpu: "1"
   env:
     - name: CLUSTER_NAME
       value: <YOUR_EKS_CLUSTER_NAME>

--- a/sample-configs/operator/collector-config-xray.yaml
+++ b/sample-configs/operator/collector-config-xray.yaml
@@ -4,6 +4,11 @@ metadata:
   name: my-collector-xray
 spec:
   mode: deployment 
+  resources:
+    requests:
+      cpu: "1"
+    limits:
+      cpu: "1"
   serviceAccount: adot-collector
   config: |
     receivers:


### PR DESCRIPTION
Signed-off-by: Raphael Silva <rapphil@gmail.com>

Description: Update examples so that they can be run reliably in EKS with Fargate. EKS with fargate nodes have default CPU set in 0.25vCPU. This is not enough to run these examples. On top of that, Fargate requires that limits and requests to be set to the same value.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

