### PR TITLE
Modularize docker compose files for Centralize Sampling sample apps

### DIFF
--- a/.github/workflows/centralized-sampling-tests.yml
+++ b/.github/workflows/centralized-sampling-tests.yml
@@ -19,8 +19,8 @@ permissions:
   id-token: write
 
 jobs:
-  run_tests:
-    name: Run centralized sampling integration tests
+  run_java_tests:
+    name: Run centralized sampling integration tests for OTel Java
     runs-on: ubuntu-latest
 
     steps:
@@ -43,7 +43,7 @@ jobs:
         run: ./gradlew :integration-tests:build
         working-directory: centralized-sampling-tests
       - name: Run test containers
-        run: docker-compose up --abort-on-container-exit
+        run: docker-compose -f docker-compose-integration-tests.yml -f docker-compose-java-app.yml up --abort-on-container-exit
         working-directory: centralized-sampling-tests
         env:
           INSTANCE_ID: ${{ github.run_id }}-${{ github.run_number }}

--- a/centralized-sampling-tests/collector-config.yml
+++ b/centralized-sampling-tests/collector-config.yml
@@ -13,7 +13,7 @@ receivers:
 
 exporters:
   logging:
-    loglevel: error
+    verbosity: normal
   awsxray:
     local_mode: true
     region: 'us-west-2'
@@ -27,6 +27,3 @@ service:
       receivers: [otlp]
       exporters: [logging]
   extensions: [health_check, awsproxy]
-  telemetry:
-    logs:
-      level: error

--- a/centralized-sampling-tests/collector-config.yml
+++ b/centralized-sampling-tests/collector-config.yml
@@ -13,7 +13,7 @@ receivers:
 
 exporters:
   logging:
-    loglevel: debug
+    loglevel: error
   awsxray:
     local_mode: true
     region: 'us-west-2'
@@ -29,4 +29,4 @@ service:
   extensions: [health_check, awsproxy]
   telemetry:
     logs:
-      level: "debug"
+      level: error

--- a/centralized-sampling-tests/docker-compose-golang-app.yml
+++ b/centralized-sampling-tests/docker-compose-golang-app.yml
@@ -1,0 +1,23 @@
+version: "3.7"
+services:
+  app:
+    build:
+      context: ./sample-apps/golang-http-server
+    depends_on:
+      - otel
+    environment:
+      - INSTANCE_ID
+      - LISTEN_ADDRESS=0.0.0.0:8080
+      - AWS_ACCESS_KEY_ID
+      - AWS_SECRET_ACCESS_KEY
+      - AWS_SESSION_TOKEN
+      - OTEL_RESOURCE_ATTRIBUTES=service.name=aws-otel-integ-test
+      - OTEL_EXPORTER_OTLP_ENDPOINT=otel:4317
+      - XRAY_ENDPOINT=http://otel:2000
+      - OTEL_JAVAAGENT_DEBUG=true
+      - OTEL_METRICS_EXPORTER=otlp
+    volumes:
+      - /tmp/awscreds:/tmp/awscreds
+    ports:
+      - '8080:8080'
+

--- a/centralized-sampling-tests/docker-compose-integration-tests.yml
+++ b/centralized-sampling-tests/docker-compose-integration-tests.yml
@@ -14,28 +14,6 @@ services:
       - '4317:4317'
       - '2000:2000'
 
-  app:
-    build:
-      context: ./sample-apps/spring-boot
-    depends_on:
-      - otel
-    environment:
-      - INSTANCE_ID
-      - LISTEN_ADDRESS=0.0.0.0:8080
-      - AWS_ACCESS_KEY_ID
-      - AWS_SECRET_ACCESS_KEY
-      - AWS_SESSION_TOKEN
-      - OTEL_RESOURCE_ATTRIBUTES=service.name=aws-otel-integ-test
-      - OTEL_EXPORTER_OTLP_ENDPOINT=http://otel:4317
-      - XRAY_ENDPOINT=http://otel:2000
-      - AWS_REGION=us-west-2
-      - OTEL_JAVAAGENT_DEBUG=true
-      - OTEL_METRICS_EXPORTER=otlp
-    volumes:
-      - /tmp/awscreds:/tmp/awscreds
-    ports:
-      - '8080:8080'
-
   integration-tests:
     build:
       context: ./integration-tests

--- a/centralized-sampling-tests/docker-compose-java-app.yml
+++ b/centralized-sampling-tests/docker-compose-java-app.yml
@@ -1,0 +1,23 @@
+version: "3.7"
+services:
+  app:
+    build:
+      context: ./sample-apps/spring-boot
+    depends_on:
+      - otel
+    environment:
+      - INSTANCE_ID
+      - LISTEN_ADDRESS=0.0.0.0:8080
+      - AWS_ACCESS_KEY_ID
+      - AWS_SECRET_ACCESS_KEY
+      - AWS_SESSION_TOKEN
+      - OTEL_RESOURCE_ATTRIBUTES=service.name=aws-otel-integ-test
+      - OTEL_EXPORTER_OTLP_ENDPOINT=http://otel:4317
+      - XRAY_ENDPOINT=http://otel:2000
+      - OTEL_JAVAAGENT_DEBUG=true
+      - OTEL_METRICS_EXPORTER=otlp
+    volumes:
+      - /tmp/awscreds:/tmp/awscreds
+    ports:
+      - '8080:8080'
+

--- a/centralized-sampling-tests/example-collector-config.yaml
+++ b/centralized-sampling-tests/example-collector-config.yaml
@@ -13,7 +13,7 @@ receivers:
 
 exporters:
   logging:
-    loglevel: error
+    verbosity: normal
   awsxray:
     local_mode: true
     region: 'us-west-2'
@@ -27,6 +27,3 @@ service:
       receivers: [otlp]
       exporters: [logging]
   extensions: [health_check, awsproxy]
-  telemetry:
-    logs:
-      level: error

--- a/centralized-sampling-tests/example-collector-config.yaml
+++ b/centralized-sampling-tests/example-collector-config.yaml
@@ -13,7 +13,7 @@ receivers:
 
 exporters:
   logging:
-    loglevel: debug
+    loglevel: error
   awsxray:
     local_mode: true
     region: 'us-west-2'
@@ -29,4 +29,4 @@ service:
   extensions: [health_check, awsproxy]
   telemetry:
     logs:
-      level: "debug"
+      level: error


### PR DESCRIPTION
Description:
Split `sample app` from the main docker-compose (which contains `otel collector` and `integration tests`).
This is to reuse the main docker-compose file for multiple sample apps that will be added in the future.

Also change OTel Collector loglevel to "error" to reduce load on OTel Collector.

Link to tracking Issue:

Testing Performed: [GH Workflow](https://github.com/jj22ee/aws-otel-community/actions/runs/4681582295/jobs/8294349307)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

