### PR TITLE
Update Centralized Sampling integration tests and Java sample app

### DIFF
--- a/centralized-sampling-tests/integration-tests/src/main/java/com.amazon.tests/CentralizedSamplingIntegrationTests.java
+++ b/centralized-sampling-tests/integration-tests/src/main/java/com.amazon.tests/CentralizedSamplingIntegrationTests.java
@@ -231,7 +231,6 @@ public class CentralizedSamplingIntegrationTests {
             }
             boolean passed = false;
             for (int j = 0; j < GenericConstants.MAX_RETRIES; j++) {
-                TimeUnit.SECONDS.sleep(GenericConstants.WAIT_FOR_RESERVOIR);
                 try {
                     passed = makeCalls(testCasesObj.getDefaultUser(), sampleRule);
                 } catch (Exception e) {
@@ -241,6 +240,7 @@ public class CentralizedSamplingIntegrationTests {
                         break;
                     } else if (j < GenericConstants.MAX_RETRIES - 1) {
                         logger.warn("Test failed, attempting retry");
+                        TimeUnit.SECONDS.sleep(GenericConstants.WAIT_FOR_RESERVOIR);
                     } else {
                         logger.error(
                                 "Test failed for Sample rule: "
@@ -295,6 +295,7 @@ public class CentralizedSamplingIntegrationTests {
                         break;
                     } else if (k < GenericConstants.MAX_RETRIES - 1) {
                         logger.warn("Test failed, attempting retry");
+                        TimeUnit.SECONDS.sleep(GenericConstants.RETRY_WAIT);
                     }
                 }
             }
@@ -354,8 +355,8 @@ public class CentralizedSamplingIntegrationTests {
                             break;
                         } else if (k < GenericConstants.MAX_RETRIES - 1) {
                             logger.warn("Test failed here, attempting retry");
+                            TimeUnit.SECONDS.sleep(GenericConstants.RETRY_WAIT);
                         }
-                        TimeUnit.SECONDS.sleep(GenericConstants.RETRY_WAIT);
                     }
                 }
                 if (!passed) {

--- a/centralized-sampling-tests/integration-tests/src/main/java/com.amazon.tests/GenericConstants.java
+++ b/centralized-sampling-tests/integration-tests/src/main/java/com.amazon.tests/GenericConstants.java
@@ -4,12 +4,12 @@ import java.util.Arrays;
 
 /** Constant global variables used in tests */
 public class GenericConstants {
-  public static final int MAX_RETRIES = 4;
+  public static final int MAX_RETRIES = 5;
   public static final int WAIT_FOR_RESERVOIR = 20;
   public static final int TOTAL_CALLS = 1000;
   public static final int DEFAULT_RATE = (int) (.05 * TOTAL_CALLS) + 1;
   public static final int DEFAULT_RANGE = 10;
-  public static final int RETRY_WAIT = 1;
+  public static final int RETRY_WAIT = 5;
   public static final String USER = "user";
   public static final String SERVICE_NAME = "service_name";
   public static final String REQUIRED = "required";

--- a/centralized-sampling-tests/integration-tests/src/main/java/com.amazon.tests/SampleRules.java
+++ b/centralized-sampling-tests/integration-tests/src/main/java/com.amazon.tests/SampleRules.java
@@ -28,8 +28,7 @@ public class SampleRules {
           getImportantRule(),
           getImportantAttribute(),
           getAttributeatEndpoint(),
-          getMethodRule(),
-          getServiceNameRule()
+          getMethodRule()
         };
 
     this.reservoirRules = new SampleRule[] {getHighReservoirLowRate(), getMixedReservoir()};
@@ -191,7 +190,7 @@ public class SampleRules {
   private SampleRule getServiceNameRule() {
     return new SampleRule.SampleRuleBuilder(
             GenericConstants.SampleRuleName.ImportantServiceName, 3, 1, 1)
-        .setServiceName("ImportantServiceName")
+        .setServiceName("aws-otel-integ-test")
         .build();
   }
 

--- a/centralized-sampling-tests/integration-tests/src/main/java/com.amazon.tests/testCases.java
+++ b/centralized-sampling-tests/integration-tests/src/main/java/com.amazon.tests/testCases.java
@@ -44,7 +44,8 @@ public class testCases {
         GenericConstants.SampleRuleName.SampleNone,
         GenericConstants.SampleRuleName.HighReservoir,
         GenericConstants.SampleRuleName.MixedReservoir,
-        GenericConstants.SampleRuleName.LowReservoir);
+        GenericConstants.SampleRuleName.LowReservoir,
+        GenericConstants.SampleRuleName.ImportantServiceName);
   }
 
   /**
@@ -309,9 +310,7 @@ public class testCases {
    * @return testCases serviceName user
    */
   private testCase getServiceNameTest() {
-    List<GenericConstants.SampleRuleName> matches =
-        getMatches(
-            new ArrayList<>(Arrays.asList(GenericConstants.SampleRuleName.ImportantServiceName)));
+    List<GenericConstants.SampleRuleName> matches = getDefaultMatches();
     return new testCase(
         GenericConstants.Users.Test.getUser(),
         "ImportantServiceName",
@@ -331,9 +330,7 @@ public class testCases {
     List<GenericConstants.SampleRuleName> matches =
         getMatches(
             new ArrayList<>(
-                Arrays.asList(
-                    GenericConstants.SampleRuleName.ImportantServiceName,
-                    GenericConstants.SampleRuleName.ImportantAttribute)));
+                Arrays.asList(GenericConstants.SampleRuleName.ImportantAttribute)));
     return new testCase(
         GenericConstants.Users.Admin.getUser(),
         "ImportantServiceName",

--- a/centralized-sampling-tests/sample-apps/spring-boot/build.gradle
+++ b/centralized-sampling-tests/sample-apps/spring-boot/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-	id 'org.springframework.boot' version '2.6.9'
+	id 'org.springframework.boot' version '2.7.5'
 	id 'io.spring.dependency-management' version '1.0.11.RELEASE'
 	id 'java'
 	id 'java-library'
@@ -12,16 +12,14 @@ repositories {
 	mavenCentral()
 }
 
-
 dependencies {
-	api(platform("io.opentelemetry.instrumentation:opentelemetry-instrumentation-bom-alpha:1.5.0-alpha"))
+	api(platform("io.opentelemetry.instrumentation:opentelemetry-instrumentation-bom-alpha:1.24.0-alpha"))
 
 	implementation("org.springframework.boot:spring-boot-starter-web")
 	implementation("org.springframework.boot:spring-boot-starter")
-	implementation("com.squareup.okhttp3:okhttp")
 	implementation("io.opentelemetry:opentelemetry-sdk")
 	implementation("io.opentelemetry:opentelemetry-api")
-	implementation("io.opentelemetry.contrib:opentelemetry-aws-xray:1.6.0")
+	implementation("io.opentelemetry.contrib:opentelemetry-aws-xray:1.24.0")
 	implementation("io.opentelemetry:opentelemetry-extension-aws")
 	implementation("io.opentelemetry.instrumentation:opentelemetry-aws-sdk-2.2")
 }


### PR DESCRIPTION
Description:
Update Integration Test cases
- Span name is now constant
- Updated XRay Sampler dependency so that the OTel Resource Service Name is used to determine Sampling Rule
- Service name rule is moved out from priority test case as the OTel Resource Service Name is also constant

Link to tracking Issue:

Testing Performed: [GH Workflow](https://github.com/jj22ee/aws-otel-community/actions/runs/4683878554)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

