### PR TITLE
Fix deprecated opentelemetry-instrumentation-aws-sdk package in javascript sample app

### DIFF
--- a/sample-apps/javascript-sample-app/nodeSDK.js
+++ b/sample-apps/javascript-sample-app/nodeSDK.js
@@ -28,7 +28,7 @@ const { OTLPTraceExporter } = require('@opentelemetry/exporter-trace-otlp-grpc')
 const { AWSXRayPropagator } = require("@opentelemetry/propagator-aws-xray");
 const { AWSXRayIdGenerator } = require("@opentelemetry/id-generator-aws-xray");
 const { HttpInstrumentation } = require("@opentelemetry/instrumentation-http");
-const { AwsInstrumentation } = require("opentelemetry-instrumentation-aws-sdk");
+const { AwsInstrumentation } = require("@opentelemetry/instrumentation-aws-sdk");
 
 const _resource = Resource.default().merge(new Resource({
         [SemanticResourceAttributes.SERVICE_NAME]: "js-sample-app",

--- a/sample-apps/javascript-sample-app/package.json
+++ b/sample-apps/javascript-sample-app/package.json
@@ -29,7 +29,7 @@
     "express": "^4.18.1",
     "js-yaml": "^4.1.0",
     "node-fetch": "^2.6.7",
-    "opentelemetry-instrumentation-aws-sdk": "^0.24.3",
+    "@opentelemetry/instrumentation-aws-sdk": "^0.34.2",
     "process": "^0.11.10"
   }
 }


### PR DESCRIPTION
The `opentelemetry-instrumentation-aws-sdk` package currently in use in the javascript-sample-app has been [deprecated in favor of @opentelemetry/instrumentation-aws-sdk](https://www.npmjs.com/package/opentelemetry-instrumentation-aws-sdk) and is producing traces with outdated names and attributes 

Example: DynamoDB span has the following name instead of `DynamoDB`
```
"{\"name\":\"dynamodb.us-west-2.amazonaws.com\"}
```

Instead, we should be using the [@opentelemetry/instrumentation-aws-sdk package](https://github.com/open-telemetry/opentelemetry-js-contrib/blob/main/plugins/node/opentelemetry-instrumentation-aws-sdk/package.json#L2) to ensure the Javascript sample app is producing the correct trace data for the `/aws-sdk-call` endpoint and that any upstream changes to the AWS SDK instrumentation are reflected in this sample app. 

Testing Performed: End-to-end test to confirm `/aws-sdk-call` endpoint is sending the correct AWS SDK instrumentation subsegments in the X-Ray console. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

