### PR TITLE
Resolving current metric related js sample app integ test failure

### DIFF
--- a/sample-apps/javascript-sample-app/request-metrics.js
+++ b/sample-apps/javascript-sample-app/request-metrics.js
@@ -17,7 +17,7 @@
 'use strict'
 
 const { SemanticAttributes } = require("@opentelemetry/semantic-conventions");
-const metricsApi = require('@opentelemetry/api-metrics');
+const api = require('@opentelemetry/api');
 
 const TOTAL_BYTES_SENT_METRIC = 'total_bytes_sent';
 const TOTAL_API_REQUESTS = 'total_api_requests';
@@ -27,8 +27,8 @@ let totalApiRequests = 0;
 
 const commmon_attributes = { signal: 'metric',  language: 'javascript', metricType: 'request' };
 
-// acquire meter 
-const meter = metricsApi.metrics.getMeter('js-sample-app-meter');
+// acquire meter
+const meter = api.metrics.getMeter('js-sample-app-meter');
 var testingId = "";
 if (process.env.INSTANCE_ID) {
     testingId = "_" + process.env.INSTANCE_ID


### PR DESCRIPTION
Description:
Resolving Current Integration test failure in JS Sample app in request based metrics. Previous PR fixed it in only random metrics: https://github.com/aws-observability/aws-otel-community/pull/506

Link to tracking Issue:CI Failure Alarm

Testing Performed: Manually on local box

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

