### PR TITLE
Revert node-fetch dep to fix JS sample app

### DIFF
--- a/sample-apps/javascript-sample-app/package.json
+++ b/sample-apps/javascript-sample-app/package.json
@@ -28,7 +28,7 @@
     "aws-sdk": "^2.1414.0",
     "express": "^4.18.2",
     "js-yaml": "^4.1.0",
-    "node-fetch": "~3.3.1",
+    "node-fetch": "~2.6.7",
     "@opentelemetry/instrumentation-aws-sdk": "^0.35.0",
     "process": "^0.11.10"
   }


### PR DESCRIPTION
Description: The group PR updated the node-fetch dependency but it should not be updated as the update would require the node-fetch dep to be imported to as an ES module.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

