### PR TITLE
Revert dependency management version

### DIFF
--- a/centralized-sampling-tests/integration-tests/build.gradle
+++ b/centralized-sampling-tests/integration-tests/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'org.springframework.boot' version '2.7.13'
-    id 'io.spring.dependency-management' version '1.1.1'
+    id 'io.spring.dependency-management' version '1.1.0'
     id 'java'
     id 'java-library'
     id 'application'

--- a/centralized-sampling-tests/sample-apps/spring-boot/build.gradle
+++ b/centralized-sampling-tests/sample-apps/spring-boot/build.gradle
@@ -1,6 +1,6 @@
 plugins {
 	id 'org.springframework.boot' version '2.7.13'
-	id 'io.spring.dependency-management' version '1.1.1'
+	id 'io.spring.dependency-management' version '1.1.0'
 	id 'java'
 	id 'java-library'
 	id 'application'


### PR DESCRIPTION
Description: Revert dependency management version which was leading to errors within the build to find dependencies.  This was working with version `1.1.0` and so this could be a due to a bug in the newest version `1.1.1` that was just released very recently.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

