### PR TITLE
Add GRPC endpoint with config and environment variable

### DIFF
--- a/sample-apps/go-sample-app/collection/client.go
+++ b/sample-apps/go-sample-app/collection/client.go
@@ -83,7 +83,11 @@ func StartClient(ctx context.Context) (func(context.Context) error, error) {
 	otel.SetTracerProvider(tp)
 	otel.SetTextMapPropagator(xray.Propagator{}) // Set AWS X-Ray propagator
 
-	exp, err := otlpmetricgrpc.New(ctx, otlpmetricgrpc.WithInsecure())
+	exp, err := otlpmetricgrpc.New(ctx,
+		otlpmetricgrpc.WithInsecure(),
+		otlpmetricgrpc.WithEndpoint(cfg.OTLPEndpointGRPC),
+	)
+
 	if err != nil {
 		return nil, err
 	}
@@ -92,7 +96,7 @@ func StartClient(ctx context.Context) (func(context.Context) error, error) {
 		metric.Stream{Aggregation: aggregation.ExplicitBucketHistogram{
 			Boundaries: []float64{100, 300, 500},
 		}},
-	)),)
+	)))
 
 	otel.SetMeterProvider(meterProvider)
 
@@ -116,7 +120,10 @@ func StartClient(ctx context.Context) (func(context.Context) error, error) {
 // setupTraceProvider configures a trace exporter and an AWS X-Ray ID Generator.
 func setupTraceProvider(ctx context.Context, res *resource.Resource) (*sdktrace.TracerProvider, error) {
 	// INSECURE !! NOT TO BE USED FOR ANYTHING IN PRODUCTION
-	traceExporter, err := otlptracegrpc.New(ctx, otlptracegrpc.WithInsecure())
+	traceExporter, err := otlptracegrpc.New(ctx,
+		otlptracegrpc.WithInsecure(),
+		otlptracegrpc.WithEndpoint(cfg.OTLPEndpointGRPC),
+	)
 
 	if err != nil {
 		return nil, err

--- a/sample-apps/go-sample-app/collection/config.go
+++ b/sample-apps/go-sample-app/collection/config.go
@@ -8,6 +8,7 @@ import (
 type Config struct {
 	Host                    string   `mapstructure:"Host"`
 	Port                    string   `mapstructure:"Port"`
+	OTLPEndpointGRPC        string   `mapstructure:"OTLPEndpointGRPC"`
 	TimeInterval            int64    `mapstructure:"TimeInterval"`
 	TimeAliveIncrementer    int64    `mapstructure:"RandomTimeAliveIncrementer"`
 	TotalHeapSizeUpperBound int64    `mapstructure:"RandomTotalHeapSizeUpperBound"`
@@ -21,6 +22,7 @@ func GetConfiguration() *Config {
 	var arr []string
 	viper.SetDefault("Host", "0.0.0.0")
 	viper.SetDefault("Port", "8080")
+	viper.SetDefault("OTLPEndpointGRPC", "localhost:4317")
 	viper.SetDefault("TimeInterval", 1)
 	viper.SetDefault("RandomTimeAliveIncrementer", 1)
 	viper.SetDefault("RandomTotalHeapSizeUpperBound", 100)
@@ -28,6 +30,8 @@ func GetConfiguration() *Config {
 	viper.SetDefault("RandomCpuUsageUpperBound", 100)
 	viper.SetDefault("SampleAppPorts", arr)
 
+	viper.AutomaticEnv()
+	viper.SetEnvPrefix("")
 	viper.SetConfigFile("config.yaml")
 	viper.ReadInConfig()
 

--- a/sample-apps/go-sample-app/config.yaml
+++ b/sample-apps/go-sample-app/config.yaml
@@ -1,6 +1,7 @@
 ---
 Host: "0.0.0.0"                       # Host - String Address
 Port: "8080"                          # Port - String Port
+OTLPGRPCEndpoint: "localhost:4317"    # OTLP exporter endpoint, GRPC - String
 TimeInterval: 1                       # Interval - Time in seconds to generate new metrics
 RandomTimeAliveIncrementer: 1         # Metric - Amount to incremement metric by every TimeInterval
 RandomTotalHeapSizeUpperBound: 100    # Metric - UpperBound for TotalHeapSize for random metric value every TimeInterval

--- a/sample-apps/go-sample-app/main.go
+++ b/sample-apps/go-sample-app/main.go
@@ -76,5 +76,4 @@ func main() {
 	}
 	fmt.Println("Listening on port:", srv.Addr)
 	log.Fatal(srv.ListenAndServe())
-
 }


### PR DESCRIPTION
Description:

This allows to run the Go app with a collector that is not `localhost` using GRPC and supporting environment variables And example would be:

```bash
 OTLPENDPOINTGRPC="adot-collector.adot-collector-kubeprometheus.svc.cluster.local:4317" PORT=8081 go run main.go
```

Link to tracking Issue: https://github.com/aws-observability/aws-otel-community/issues/585

Testing Performed:

EKS manifest (truncated for brevity)

```yaml
    spec:
      containers:
        - name: go-sample-app
          image: "${ECR_REPOSITORY_URI}:latest"
          imagePullPolicy: Always
          env:
          - name: OTLPENDPOINTGRPC
            value: adot-collector.adot-collector-kubeprometheus.svc.cluster.local:4317
          resources:
```

Ran the app on EKS and able to see traces 
<img width="1861" alt="image" src="https://github.com/aws-observability/aws-otel-community/assets/10175027/1028f428-c2ef-4bd2-8114-0d0961d7cdd8">


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

