### PR TITLE
Fix: remove the need to explicitly define the version in gradle script

### DIFF
--- a/sample-apps/java-sample-app/auto/build.gradle.kts
+++ b/sample-apps/java-sample-app/auto/build.gradle.kts
@@ -32,6 +32,10 @@ repositories {
     mavenCentral()
 }
 
+
+val javaAgent = "software.amazon.opentelemetry:aws-opentelemetry-agent:1.30.0"
+val javaAgentVersion = javaAgent.split(":").get(2)
+
 jib {
     from {
         image= "eclipse-temurin:17"
@@ -49,13 +53,10 @@ jib {
     container {
         ports = listOf("8080")
         jvmFlags = listOf(
-            "-javaagent:aws-opentelemetry-agent-1.29.0.jar",
+            "-javaagent:aws-opentelemetry-agent-${javaAgentVersion}.jar",
             "-Dotel.javaagent.extensions=${buildDir}/javaagent/extension.jar")
     }
 }
-
-val javaAgent = "software.amazon.opentelemetry:aws-opentelemetry-agent:1.30.0"
-val javaAgentVersion = javaAgent.split(":").get(2)
 
 dependencies {
     // Base application

--- a/sample-apps/java-sample-app/auto/build.gradle.kts
+++ b/sample-apps/java-sample-app/auto/build.gradle.kts
@@ -54,12 +54,15 @@ jib {
     }
 }
 
+val javaAgent = "software.amazon.opentelemetry:aws-opentelemetry-agent:1.30.0"
+val javaAgentVersion = javaAgent.split(":").get(2)
+
 dependencies {
     // Base application
     implementation(project(":base"))
 
     // Necessary to download the jar of the Java Agent
-    javaagentDependency("software.amazon.opentelemetry:aws-opentelemetry-agent:1.30.0")
+    javaagentDependency(javaAgent)
     javaagentDependency(project(":extension"))
 }
 
@@ -67,7 +70,7 @@ dependencies {
 application {
     mainClass.set("software.amazon.adot.sampleapp.MainAuto")
     applicationDefaultJvmArgs = listOf(
-        "-javaagent:$buildDir/javaagent/aws-opentelemetry-agent-1.29.0.jar", // Use the Java agent when the application is run
+        "-javaagent:$buildDir/javaagent/aws-opentelemetry-agent-${javaAgentVersion}.jar", // Use the Java agent when the application is run
         "-Dotel.service.name=java-sample-app",  // sets the name of the application in traces and metrics.
         "-Dotel.javaagent.extensions=${buildDir}/javaagent/extension.jar")
 }


### PR DESCRIPTION
Description: Remove the need to explicitly set the java agent version in parameters that cannot be updated by dependabot.

This will allow the command line parameter and the dependency to remain aligned.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

