### PR TITLE
Ignore Flask major upgrades in dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -58,6 +58,10 @@ updates:
       python-auto-sample-app-deps:
         patterns:
           - "*"
+    ignore:
+      - dependency-name: "Flask"
+        update-types:
+          - "version-update:semver-major"
   - package-ecosystem: "pip"
     directory: "/sample-apps/python-manual-instrumentation-sample-app"
     schedule:
@@ -67,6 +71,10 @@ updates:
       python-manual-sample-app-deps:
         patterns:
           - "*"
+    ignore:
+      - dependency-name: "Flask"
+        update-types:
+          - "version-update:semver-major"
   - package-ecosystem: "bundler"
     directory: "/sample-apps/ruby-rails-sample-app"
     schedule:

--- a/sample-apps/python-manual-instrumentation-sample-app/requirements.txt
+++ b/sample-apps/python-manual-instrumentation-sample-app/requirements.txt
@@ -1,5 +1,5 @@
-boto3==1.28.69
-Flask==3.0.0
+boto3==1.28.52
+Flask==2.3.3
 opentelemetry-distro==0.41b0
 opentelemetry-exporter-otlp==1.20.0
 opentelemetry-api==1.20.0
@@ -8,6 +8,6 @@ opentelemetry-instrumentation-requests==0.41b0
 opentelemetry-instrumentation-botocore==0.41b0
 opentelemetry-sdk-extension-aws==2.0.1
 opentelemetry-propagator-aws-xray==1.0.1
-protobuf==4.24.4
+protobuf==4.24.3
 PyYAML==6.0.1
 requests==2.31.0


### PR DESCRIPTION
Description:
`Flask==3.0.0`  is not included in [opentelemetry-instrumentation-flask](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/eb6024ca3171072daa5d842d9363e41d72ee64a6/instrumentation/opentelemetry-instrumentation-flask/pyproject.toml#L38) yet and hence leading to the failures for this major upgrade. Hence ignoring the upgrade.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

