### PR TITLE
Use axios instead of fetch

### DIFF
--- a/sample-apps/javascript-sample-app/package.json
+++ b/sample-apps/javascript-sample-app/package.json
@@ -17,6 +17,7 @@
     "@opentelemetry/exporter-prometheus": "^0.45.1",
     "@opentelemetry/exporter-trace-otlp-grpc": "^0.45.1",
     "@opentelemetry/id-generator-aws-xray": "^1.2.1",
+    "@opentelemetry/instrumentation-aws-sdk": "^0.36.2",
     "@opentelemetry/instrumentation-http": "^0.45.1",
     "@opentelemetry/propagator-aws-xray": "^1.3.1",
     "@opentelemetry/resources": "^1.18.1",
@@ -26,10 +27,10 @@
     "@opentelemetry/sdk-trace-node": "^1.18.1",
     "@opentelemetry/semantic-conventions": "^1.18.1",
     "aws-sdk": "^2.1500.0",
+    "axios": "^1.6.2",
     "express": "^4.18.2",
     "js-yaml": "^4.1.0",
     "node-fetch": "~2.7.0",
-    "@opentelemetry/instrumentation-aws-sdk": "^0.36.2",
     "process": "^0.11.10"
   }
 }

--- a/sample-apps/javascript-sample-app/server.js
+++ b/sample-apps/javascript-sample-app/server.js
@@ -18,7 +18,7 @@
 
 const http = require('http');
 const AWS = require('aws-sdk');
-const fetch = require ("node-fetch");
+const axios = require('axios');
 
 // config
 const create_cfg = require('./config');
@@ -118,15 +118,15 @@ function mimicPayLoadSize() {
 }
 
 async function httpCall(url) {
-    try {
-        const response = await fetch(url); 
-        console.log(`made a request to ${url}`);
-        if (!response.ok) {
+    axios.get(url)
+    .then(response => {
+        if (response.statusText != "OK") {
             throw new Error(`Error! status: ${response.status}`);
         }
-    } catch (err) {
-        throw new Error(`Error while fetching the ${url}`, err);
-    }
+    })
+    .catch(error => {
+        throw new Error(`Error while fetching the ${url}`, error);
+    });
 }
 
 async function instrumentRequest(spanName, _callback) {


### PR DESCRIPTION
Description: The Javascript sample app was not properly propagating the trace context when using fetch for certain URLs.  Have changed to use `axios` for HTTPS requests instead to fix this.

Testing Performed: Locally tested and passed.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

