### PR TITLE
Add Flask instrumentation explicitly in Python Auto Instrumentation

### DIFF
--- a/sample-apps/python-auto-instrumentation-sample-app/app.py
+++ b/sample-apps/python-auto-instrumentation-sample-app/app.py
@@ -17,7 +17,7 @@ from opentelemetry import trace, metrics
 
 from typing import Iterable
 from flask import Flask, request
-
+from opentelemetry.instrumentation.flask import FlaskInstrumentor
 
 from opentelemetry.metrics import CallbackOptions, Observation
 
@@ -26,6 +26,7 @@ tracer = trace.get_tracer(__name__)
 meter = metrics.get_meter(__name__)
 
 app = Flask(__name__)
+FlaskInstrumentor().instrument_app(app)
 
 cfg = create_config('config.yaml')
 


### PR DESCRIPTION
Description: We were experiencing an issue with Flask instrumentation after we were not seeing the correct spans being produced in the python-auto-instrumentation-sample-app.  Explicitly defining the Flask instrumentation fixes this issue.

Testing Performed: Test passed locally.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

