### PR TITLE
Fix the sample apps for integration tests

### DIFF
--- a/sample-apps/dotnet-sample-app/README.md
+++ b/sample-apps/dotnet-sample-app/README.md
@@ -34,7 +34,7 @@ In order to run the application
 `cd sample-apps/dotnet-sample-app`
 - Install dependencies
 `dotnet build`
-- Run the javascript server
+- Run the .NET server
 `dotnet run`
 Now the application is ran and the endpoints can be called at `0.0.0.0:8080/<one-of-4-endpoints>`.
 

--- a/sample-apps/dotnet-sample-app/dotnet-sample-app.csproj
+++ b/sample-apps/dotnet-sample-app/dotnet-sample-app.csproj
@@ -10,7 +10,7 @@
     <PackageReference Include="OpenTelemetry.Contrib.Instrumentation.AWS" Version="1.0.2" />
     <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.7.0" />
     <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.0.0-rc9.14" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.7.0" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.0.0-rc9.14" />
     <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="8.0.0" />
     <PackageReference Include="YamlDotNet" Version="13.7.1" />
 

--- a/sample-apps/javascript-sample-app/server.js
+++ b/sample-apps/javascript-sample-app/server.js
@@ -120,7 +120,7 @@ function mimicPayLoadSize() {
 async function httpCall(url) {
     axios.get(url)
     .then(response => {
-        if (response.statusText != "OK") {
+        if (response.status != "200") {
             throw new Error(`Error! status: ${response.status}`);
         }
     })


### PR DESCRIPTION
Description: The JS sample app required tweaking to the if conditional to perform the HTTP call.  For dotnet, the error is stemming from the update to the HTTP instrumentation that is due to the new semantic conventions.

Testing Performed: Local testing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

