### PR TITLE
Update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,5 @@
 * @aws-observability/adot-collector-maintainers
 
-sample-apps                           @aws-observability/aws-application-signals-maintainers
-sample-apps/prometheus-sample-app     @aws-observability/adot-collector-maintainers
+sample-apps                            @aws-observability/aws-application-signals-maintainers
+.github/workflows/integration-test.yml @aws-observability/aws-application-signals-maintainers
+sample-apps/prometheus-sample-app      @aws-observability/adot-collector-maintainers


### PR DESCRIPTION
aws-application-signals-maintainers is responsible for integ-test workflow

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

