### PR TITLE
Align failure metrics with existing metrics

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -83,12 +83,12 @@ jobs:
         run: |
           if [ '${{ needs.publish_and_test_app.result }}' = 'success' ]; then
             aws cloudwatch put-metric-data --namespace 'ADOT/GitHubActions' \
-              --metric-name Success \
-              --dimensions repository=${{ github.repository }},branch=${{ github.ref_name }},workflow=integration-test \
-              --value 1.0
-          else
-            aws cloudwatch put-metric-data --namespace 'ADOT/GitHubActions' \
-              --metric-name Success \
+              --metric-name Failure \
               --dimensions repository=${{ github.repository }},branch=${{ github.ref_name }},workflow=integration-test \
               --value 0.0
+          else
+            aws cloudwatch put-metric-data --namespace 'ADOT/GitHubActions' \
+              --metric-name Failure \
+              --dimensions repository=${{ github.repository }},branch=${{ github.ref_name }},workflow=integration-test \
+              --value 1.0
           fi


### PR DESCRIPTION
Change `Success` metrics to `Failure` metrics, for easier monitoring.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

