### PR TITLE
Use Debug Exporter in the ADOT collector configurations

### DIFF
--- a/.github/collector/collector-config.yml
+++ b/.github/collector/collector-config.yml
@@ -8,8 +8,8 @@ processors:
   batch:
 
 exporters:
-  logging:
-    loglevel: info
+  debug:
+    verbosity: normal
   awsxray:
     region: us-west-2
   awsemf:
@@ -26,7 +26,7 @@ service:
       processors:
         - batch
       exporters:
-        - logging
+        - debug
         - awsxray
     metrics:
       receivers:
@@ -34,5 +34,5 @@ service:
       processors:
         - batch
       exporters:
-        - logging
+        - debug
         - awsemf

--- a/centralized-sampling-tests/collector-config.yml
+++ b/centralized-sampling-tests/collector-config.yml
@@ -12,7 +12,7 @@ receivers:
       http:
 
 exporters:
-  logging:
+  debug:
     verbosity: normal
   awsxray:
     local_mode: true
@@ -22,8 +22,8 @@ service:
   pipelines:
     traces:
       receivers: [otlp]
-      exporters: [logging, awsxray]
+      exporters: [debug, awsxray]
     metrics:
       receivers: [otlp]
-      exporters: [logging]
+      exporters: [debug]
   extensions: [health_check, awsproxy]

--- a/centralized-sampling-tests/example-collector-config.yaml
+++ b/centralized-sampling-tests/example-collector-config.yaml
@@ -12,7 +12,7 @@ receivers:
       http:
 
 exporters:
-  logging:
+  debug:
     verbosity: normal
   awsxray:
     local_mode: true
@@ -22,8 +22,8 @@ service:
   pipelines:
     traces:
       receivers: [otlp]
-      exporters: [logging, awsxray]
+      exporters: [debug, awsxray]
     metrics:
       receivers: [otlp]
-      exporters: [logging]
+      exporters: [debug]
   extensions: [health_check, awsproxy]

--- a/sample-apps/dotnet-sample-app/collector-config-local.yml
+++ b/sample-apps/dotnet-sample-app/collector-config-local.yml
@@ -5,8 +5,8 @@ receivers:
         endpoint: 0.0.0.0:4317
 
 exporters:
-  logging:
-    loglevel: debug
+  debug:
+    verbosity: detailed
   awsxray:
     region: us-west-2
   awsemf:
@@ -18,11 +18,11 @@ service:
       receivers:
         - otlp
       exporters:
-        - logging
+        - debug
         - awsxray
     metrics:
       receivers:
         - otlp
       exporters:
-        - logging
+        - debug
         - awsemf

--- a/sample-apps/java-sample-app/collector-config.yaml
+++ b/sample-apps/java-sample-app/collector-config.yaml
@@ -22,8 +22,8 @@ processors:
   batch:
 
 exporters:
-  logging:
-    loglevel: debug
+  debug:
+    verbosity: detailed
   awsxray:
     region: us-west-2
 
@@ -36,8 +36,8 @@ service:
     traces:
       receivers: [otlp]
       processors: [batch]
-      exporters: [awsxray,logging]
+      exporters: [awsxray,debug]
     metrics:
       receivers: [otlp]
       processors: [batch]
-      exporters: [awsemf, logging]
+      exporters: [awsemf, debug]

--- a/sample-apps/prometheus-sample-app/otel-collector-k8s-deployment.yaml
+++ b/sample-apps/prometheus-sample-app/otel-collector-k8s-deployment.yaml
@@ -18,14 +18,14 @@ data:
               action: keep
     processors:
     exporters:
-      logging:
-        loglevel: debug
+      debug:
+        verbosity: debug
     service:
       pipelines:
         metrics:
           receivers: [prometheus]
           processors: []
-          exporters: [logging]
+          exporters: [debug]
 ---
 apiVersion: apps/v1
 kind: Deployment


### PR DESCRIPTION
Description:


Use Debug Exporter in the ADOT collector configurations

https://aws-otel.github.io/docs/ReleaseBlogs/aws-distro-for-opentelemetry-collector-v0.42.0

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

