### PR TITLE
Updating variable declaration in collector-config-amp.yaml

### DIFF
--- a/sample-configs/operator/collector-config-amp.yaml
+++ b/sample-configs/operator/collector-config-amp.yaml
@@ -288,7 +288,7 @@ spec:
               target_label: __address__
             - action: labelmap
               regex: __meta_kubernetes_pod_annotation_prometheus_io_param_(.+)
-              replacement: __param_$1
+              replacement: __param_$$1
             - action: labelmap
               regex: __meta_kubernetes_pod_label_(.+)
             - action: replace


### PR DESCRIPTION
Description: When applying collector-config-amp.yaml, all variables in the yaml need to have double $ signs ($$var). However, one line managed to sneak in, causing parsing errors in the collector pods:
```
Error: failed to resolve config: cannot resolve the configuration: cannot convert the confmap.Conf: environment variable "1" has invalid name: must match regex ^[a-zA-Z_][a-zA-Z0-9_]*$
2025/02/04 18:38:44 application run finished with error: failed to resolve config: cannot resolve the configuration: cannot convert the confmap.Conf: environment variable "1" has invalid name: must match regex ^[a-zA-Z_][a-zA-Z0-9_]*$
```

Link to tracking Issue:

Testing Performed: 
`kubectl apply -f collector-config-amp.yaml` returns the above error in the collector pods. Dashboards aren't populated until this `$` --> `$$` change is made

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

